### PR TITLE
Retrieve messages by ID and keep deleted entities for animation

### DIFF
--- a/src/chat/ChatMessage.js
+++ b/src/chat/ChatMessage.js
@@ -1,10 +1,17 @@
 import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
 import colorHash from 'helpers/colorHash'
 import emoji from 'helpers/emoji'
 
-const ChatMessage = ({ message = {}, user = '', styles, style }) => {
-  const username = typeof user === 'string' ? user : user.name
-  const color = typeof user === 'string' ? colorHash(username) : `#${user.color}`
+import {
+  makeGetChatMessageEntity,
+  makeGetChatUserEntity
+} from './chatSelectors'
+
+export const ChatMessage = ({ message = {}, user = 'anon', styles, style }) => {
+  const isUserString = typeof user === 'string'
+  const username = isUserString ? user : user.name
+  const color = isUserString ? colorHash(username) : `#${user.color}`
 
   return (
     <li style={style} className={styles.message}>
@@ -26,4 +33,16 @@ ChatMessage.propTypes = {
   style: PropTypes.object.isRequired
 }
 
-export default ChatMessage
+const makeMapStateToProps = () => {
+  const getChatMessageEntity = makeGetChatMessageEntity()
+  const getChatUserEntity = makeGetChatUserEntity()
+
+  return (state, { id }) => {
+    const message = getChatMessageEntity(state, id)
+    const user = message.username || getChatUserEntity(state, message.user)
+
+    return {message, user}
+  }
+}
+
+export default connect(makeMapStateToProps)(ChatMessage)

--- a/src/chat/ChatMessageList.js
+++ b/src/chat/ChatMessageList.js
@@ -6,11 +6,7 @@ import { connect } from 'react-redux'
 import { TransitionMotion, spring, presets } from 'react-motion'
 
 import ChatMessage from './ChatMessage'
-import {
-  getChatMessageIds,
-  getChatMessageEntities,
-  getChatUserEntities
-} from './chatSelectors'
+import { getChatMessageIds } from './chatSelectors'
 
 const { bool, object, array } = PropTypes
 
@@ -73,18 +69,12 @@ class ChatMessageList extends Component {
   }
 
   getStyles (style = {}) {
-    const { messageIds, messages, users } = this.props
+    const { messageIds } = this.props
 
-    return messageIds.map(id => {
-      const message = messages[id]
-      const user = message.username || users[message.user]
-
-      return {
-        key: id,
-        style: {...style},
-        data: { message, user }
-      }
-    })
+    return messageIds.map(id => ({
+      key: id,
+      style: {...style}
+    }))
   }
 
   getWillEnterStyles = () => ({
@@ -101,7 +91,7 @@ class ChatMessageList extends Component {
     this.list = el
   }
 
-  renderMessage = ({ key, style: { opacity, translateX }, data }) => {
+  renderMessage = ({ key, style: { opacity, translateX } }) => {
     const { styles } = this.props
 
     const style = {
@@ -109,7 +99,7 @@ class ChatMessageList extends Component {
       transform: `translateX(${translateX}%)`
     }
 
-    const props = { ...data, key, style, styles }
+    const props = { id: key, key, style, styles }
 
     return <ChatMessage {...props} />
   }
@@ -153,9 +143,7 @@ class ChatMessageList extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  messageIds: getChatMessageIds(state),
-  messages: getChatMessageEntities(state),
-  users: getChatUserEntities(state)
+  messageIds: getChatMessageIds(state)
 })
 
 export default connect(mapStateToProps)(ChatMessageList)

--- a/src/chat/chatReducer.js
+++ b/src/chat/chatReducer.js
@@ -49,8 +49,6 @@ function entities (state = initialState.get('entities'), action) {
     case FETCH_CHAT_USERS_SUCCESS:
     case ADD_CHAT_MESSAGE:
       return state.mergeDeep(action.response.entities)
-    case REMOVE_CHAT_MESSAGE:
-      return state.deleteIn(['messages', action.ts])
     default:
       return state
   }

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -61,3 +61,23 @@ export const getChatUserEntities = createSelector(
   getChatUserEntititesState,
   entities => entities.toJS()
 )
+
+const getChatMessageEntityState = (state, id) =>
+  state.getIn(['chat', 'entities', 'messages', id])
+
+export const makeGetChatMessageEntity = () => {
+  return createSelector(
+    getChatMessageEntityState,
+    entity => entity.toObject()
+  )
+}
+
+const getChatUserEntityState = (state, id) =>
+  state.getIn(['chat', 'entities', 'users', id])
+
+export const makeGetChatUserEntity = () => {
+  return createSelector(
+    getChatUserEntityState,
+    entity => entity.toObject()
+  )
+}


### PR DESCRIPTION
Should avoid unnecessary re-renders, while still allowing us to animate out messages that gets removed.