### PR TITLE
feat: limit session middleware to graphql path

### DIFF
--- a/lib/createServer.js
+++ b/lib/createServer.js
@@ -54,22 +54,26 @@ module.exports = async (app /*: NextApp */) => {
     server.use(helmet())
   }
 
-  server.use(session({ secret, resave: false, saveUninitialized: false }))
   server.use(compression())
   server.use(fragmentTypes(graphqlSchema))
   server.use(express.static(path.resolve(__dirname, '..', 'public')))
 
-  server.use((
-    req /*: Request */,
-    res /*: Response */,
-    next /*: NextFunction */
-  ) => {
-    if (!req.session.username) {
-      req.session.username = randomName()
-    }
+  server.use(
+    '/graphql',
+    session({
+      secret,
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: 'auto' },
+    }),
+    (req /*: Request */, res /*: Response */, next /*: NextFunction */) => {
+      if (!req.session.username) {
+        req.session.username = randomName()
+      }
 
-    next()
-  })
+      next()
+    }
+  )
 
   apolloServer.applyMiddleware({ app: server })
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,6 +4,6 @@ const session = require('express-session')
 const RedisStore = require('connect-redis')(session)
 const client = require('./redis')
 
-const store = new RedisStore({ client })
+const store = new RedisStore({ client, disableTTL: true })
 
 module.exports = opts => session({ ...opts, store })


### PR DESCRIPTION
Since we only use the session in graphql requests, we add a lot of overhead attaching it to every request. This resolves it by limiting the path for the session middlewares to `/graphql`.

Additionally this change sets `cookie.secure` to `auto`, to ensure the cookie is limited to https only in production. It also disables the default TTL for the redis session handler, so we can rely on the server's eviction policy instead.