### PR TITLE
fix: extract fragment types from plain schema

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,6 +4,7 @@ const { resolve } = require('path')
 
 module.exports = {
   src: resolve('src'),
+  lib: resolve('lib'),
   dest: resolve('.next'),
   title: 'Simon Kjellberg',
   description:


### PR DESCRIPTION
This ensures the build can be run in a "clean" environment, without the environment settings necessary for running the full-fledged server.