### PR TITLE
fix: correct safe-area handling

### DIFF
--- a/src/components/Header.bs.js
+++ b/src/components/Header.bs.js
@@ -25,14 +25,17 @@ var container = Css.style(/* :: */[
         /* :: */[
           Css.padding2(Css.rem(1.45), Css.rem(1.0875)),
           /* :: */[
-            Css.unsafe("padding-top", "max(1.45rem, env(safe-area-inset-top))"),
-            /* :: */[
-              Css.unsafe("padding-left", "max(1.0875rem, env(safe-area-inset-left))"),
-              /* :: */[
-                Css.unsafe("padding-right", "max(1.0875rem, env(safe-area-inset-right))"),
-                /* [] */0
-              ]
-            ]
+            Css.unsafe("@supports(padding: max(0px)) and (padding: env(safe-area-inset-top))", Css.style(/* :: */[
+                      Css.unsafe("padding-top", "max(env(safe-area-inset-top), 1.45rem)"),
+                      /* :: */[
+                        Css.unsafe("padding-left", "max(env(safe-area-inset-left), 1.0875rem)"),
+                        /* :: */[
+                          Css.unsafe("padding-right", "max(env(safe-area-inset-right), 1.0875rem)"),
+                          /* [] */0
+                        ]
+                      ]
+                    ])),
+            /* [] */0
           ]
         ]
       ]

--- a/src/components/Header.re
+++ b/src/components/Header.re
@@ -15,9 +15,17 @@ module Styles = {
       margin2(~v=`zero, ~h=`auto),
       maxWidth(rem(35.0)),
       padding2(~v=rem(1.45), ~h=rem(1.0875)),
-      unsafe("padding-top", "max(1.45rem, env(safe-area-inset-top))"),
-      unsafe("padding-left", "max(1.0875rem, env(safe-area-inset-left))"),
-      unsafe("padding-right", "max(1.0875rem, env(safe-area-inset-right))"),
+      unsafe(
+        "@supports(padding: max(0px)) and (padding: env(safe-area-inset-top))",
+        style([
+          unsafe("padding-top", "max(env(safe-area-inset-top), 1.45rem)"),
+          unsafe("padding-left", "max(env(safe-area-inset-left), 1.0875rem)"),
+          unsafe(
+            "padding-right",
+            "max(env(safe-area-inset-right), 1.0875rem)",
+          ),
+        ]),
+      ),
     ]);
 
   let title =

--- a/src/components/Page.bs.js
+++ b/src/components/Page.bs.js
@@ -33,14 +33,17 @@ var content = Css.style(/* :: */[
         /* :: */[
           Css.padding3(/* zero */-789508312, Css.rem(0.9375), Css.rem(1.875)),
           /* :: */[
-            Css.unsafe("padding-left", "max(0.9375rem, env(safe-area-inset-left))"),
-            /* :: */[
-              Css.unsafe("padding-right", "max(0.9375rem, env(safe-area-inset-left))"),
-              /* :: */[
-                Css.unsafe("padding-bottom", "max(1.875rem, env(safe-area-inset-bottom))"),
-                /* [] */0
-              ]
-            ]
+            Css.unsafe("@supports(padding: max(0px)) and (padding: env(safe-area-inset-bottom))", Css.style(/* :: */[
+                      Css.unsafe("padding-left", "max(env(safe-area-inset-left), 0.9375rem)"),
+                      /* :: */[
+                        Css.unsafe("padding-right", "max(env(safe-area-inset-right), 0.9375rem)"),
+                        /* :: */[
+                          Css.unsafe("padding-bottom", "max(env(safe-area-inset-bottom), 1.875rem)"),
+                          /* [] */0
+                        ]
+                      ]
+                    ])),
+            /* [] */0
           ]
         ]
       ]

--- a/src/components/Page.re
+++ b/src/components/Page.re
@@ -16,9 +16,20 @@ module Styles = {
       margin2(~v=`zero, ~h=`auto),
       maxWidth(Theme.Page.maxWidth),
       padding3(~top=`zero, ~h=rem(0.9375), ~bottom=rem(1.875)),
-      unsafe("padding-left", "max(0.9375rem, env(safe-area-inset-left))"),
-      unsafe("padding-right", "max(0.9375rem, env(safe-area-inset-left))"),
-      unsafe("padding-bottom", "max(1.875rem, env(safe-area-inset-bottom))"),
+      unsafe(
+        "@supports(padding: max(0px)) and (padding: env(safe-area-inset-bottom))",
+        style([
+          unsafe("padding-left", "max(env(safe-area-inset-left), 0.9375rem)"),
+          unsafe(
+            "padding-right",
+            "max(env(safe-area-inset-right), 0.9375rem)",
+          ),
+          unsafe(
+            "padding-bottom",
+            "max(env(safe-area-inset-bottom), 1.875rem)",
+          ),
+        ]),
+      ),
     ]);
 };
 let component = ReasonReact.statelessComponent("Link");

--- a/src/components/__snapshots__/Header.test.js.snap
+++ b/src/components/__snapshots__/Header.test.js.snap
@@ -11,9 +11,14 @@ exports[`<Header /> 1`] = `
   margin: 0 auto;
   max-width: 35rem;
   padding: 1.45rem 1.0875rem;
-  padding-top: max(1.45rem,env(safe-area-inset-top));
-  padding-left: max(1.0875rem,env(safe-area-inset-left));
-  padding-right: max(1.0875rem,env(safe-area-inset-right));
+}
+
+@supports (padding:max(0px)) and (padding:env(safe-area-inset-top)) {
+  .emotion-2 {
+    padding-top: max(env(safe-area-inset-top),1.45rem);
+    padding-left: max(env(safe-area-inset-left),1.0875rem);
+    padding-right: max(env(safe-area-inset-right),1.0875rem);
+  }
 }
 
 .emotion-1 {

--- a/src/components/__snapshots__/Page.test.js.snap
+++ b/src/components/__snapshots__/Page.test.js.snap
@@ -11,9 +11,14 @@ exports[`<Page /> 1`] = `
   margin: 0 auto;
   max-width: 35rem;
   padding: 1.45rem 1.0875rem;
-  padding-top: max(1.45rem,env(safe-area-inset-top));
-  padding-left: max(1.0875rem,env(safe-area-inset-left));
-  padding-right: max(1.0875rem,env(safe-area-inset-right));
+}
+
+@supports (padding:max(0px)) and (padding:env(safe-area-inset-top)) {
+  .emotion-2 {
+    padding-top: max(env(safe-area-inset-top),1.45rem);
+    padding-left: max(env(safe-area-inset-left),1.0875rem);
+    padding-right: max(env(safe-area-inset-right),1.0875rem);
+  }
 }
 
 .emotion-1 {
@@ -40,9 +45,14 @@ exports[`<Page /> 1`] = `
   margin: 0 auto;
   max-width: 35rem;
   padding: 0 0.9375rem 1.875rem;
-  padding-left: max(0.9375rem,env(safe-area-inset-left));
-  padding-right: max(0.9375rem,env(safe-area-inset-left));
-  padding-bottom: max(1.875rem,env(safe-area-inset-bottom));
+}
+
+@supports (padding:max(0px)) and (padding:env(safe-area-inset-bottom)) {
+  .emotion-4 {
+    padding-left: max(env(safe-area-inset-left),0.9375rem);
+    padding-right: max(env(safe-area-inset-right),0.9375rem);
+    padding-bottom: max(env(safe-area-inset-bottom),1.875rem);
+  }
 }
 
 <div

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -87,6 +87,11 @@ class App extends NextApp {
       <Container>
         <Global styles={globalStyles} />
         <Head>
+          <meta
+            name="viewport"
+            key="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+          />
           <meta property="og:type" content="website" key="og:type" />
           <meta property="og:url" content={canonicalUrl} key="og:url" />
           <meta

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -36,10 +36,6 @@ export default class Document extends NextDocument {
           <link rel="manifest" href="/manifest.json" />
           <link rel="shortcut icon" href="/favicon.ico" />
           <meta name="theme-color" content="#000000" />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
-          />
           {this.props.browserTimingHeader != null && (
             <script
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
Padding disappeared in Chrome 74 due to breaking changes.
Next.js had also silently introduced a breaking change in Head.