### PR TITLE
fix(CaretBuddy): move animation frame ref reset into effect

### DIFF
--- a/app/components/chat/CaretBuddy.tsx
+++ b/app/components/chat/CaretBuddy.tsx
@@ -116,11 +116,11 @@ function useFrameAnimation(frames: AnimationFrames): string {
   const [prevFrames, setPrevFrames] = useState(frames);
   if (frames !== prevFrames) {
     setPrevFrames(frames);
-    frameIndexRef.current = 0;
     setExpression(frames[0][1]);
   }
 
   useEffect(() => {
+    frameIndexRef.current = 0;
     let startTime: number | null = null;
     let raf: number;
 


### PR DESCRIPTION
eslint-plugin-react-hooks 7.1.0 added a `react-hooks/refs` rule that
flags ref mutation during render. Resetting `frameIndexRef.current` in
the effect that owns the animation (already keyed on `frames`) keeps
behavior identical and unblocks the lock file maintenance PR — its
lockfile bumps the plugin from 7.0.1 to 7.1.1, breaking lint and in
turn skipping the test step (no junit.xml for codecov to upload).