### PR TITLE
chore: drop verbose comment from Dockerfile deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable pnpm
 
-# Use cache mount for pnpm store. --ignore-scripts skips the prepare
-# lifecycle script, which runs `husky && next typegen` and needs .git
-# and app/ — neither is present in this stage.
+# Use cache mount for pnpm store
 RUN --mount=type=cache,id=s/ef8993ce-cfd2-4811-8cd1-005564b52ee4-/root/.local/share/pnpm/store,target=/root/.local/share/pnpm/store \
     pnpm i --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
Removes a chatty AI-style comment added in #1798 that just narrated what `--ignore-scripts` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)