### PR TITLE
chore: extend config:best-practices in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:js-app",
-    "helpers:pinGitHubActionDigests",
-    ":configMigration",
-    ":maintainLockFilesWeekly",
+    "config:best-practices",
+    ":pinAllExceptPeerDependencies",
     ":automergePatch",
     ":automergeDigest",
     ":automergeLinters",


### PR DESCRIPTION
## Summary

- Replace `config:js-app` with `config:best-practices`, gaining `docker:pinDigests`, `abandonments:recommended`, `security:minimumReleaseAgeNpm`, and `:pinDevDependencies`
- Remove 3 presets now redundant with `best-practices`: `helpers:pinGitHubActionDigests`, `:configMigration`, `:maintainLockFilesWeekly`
- Add back `:pinAllExceptPeerDependencies` (was provided by `config:js-app` but not included in `best-practices`)

## Test plan

- [ ] Verify Renovate validates the config (Renovate will auto-check on next run or via the [config validator](https://docs.renovatebot.com/config-validation/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)