### PR TITLE
Prevent timestamp wrapping in recent tracks list

### DIFF
--- a/app/components/RecentTracksList.tsx
+++ b/app/components/RecentTracksList.tsx
@@ -28,7 +28,7 @@ export const RecentTracksList = ({ recentTracks }: RecentTracksListProps) => {
   }
 
   return (
-    <ul>
+    <ul className="recent-tracks">
       {result.tracks.map((track) => (
         <li key={`${track.name}-${track.playedAt?.getTime()}`}>
           <>{track.name}</> &ndash; <em>{track.artist}</em>{" "}

--- a/app/global.css
+++ b/app/global.css
@@ -165,6 +165,12 @@ ul {
   font-weight: normal;
 }
 
+/* Keep the played-at timestamp parenthetical from breaking mid-phrase so the
+   whole "(12 minutes ago)" wraps onto the next line instead of orphaning. */
+.recent-tracks .subtitle {
+  white-space: nowrap;
+}
+
 @keyframes loading-dots {
   0% {
     content: "";


### PR DESCRIPTION
## Summary

Fixes layout issue where the played-at timestamp in the recent tracks list could break mid-phrase, orphaning part of the timestamp on a new line.

## Changes

- Added `className="recent-tracks"` to the `<ul>` in `RecentTracksList.tsx` to enable targeted styling
- Added CSS rule with `white-space: nowrap` to `.recent-tracks .subtitle` to keep the entire timestamp phrase (e.g., "(12 minutes ago)") together on one line, allowing the whole phrase to wrap to the next line instead of breaking mid-phrase

## Implementation Details

The subtitle containing the played-at timestamp is rendered as a child of each list item. By applying `white-space: nowrap` to the subtitle, we ensure the timestamp parenthetical stays intact as a single unit, improving readability and visual consistency.

https://claude.ai/code/session_01SdpsjQupAgmEdjAycigMyL